### PR TITLE
Enable enemy controller script upon coming in view

### DIFF
--- a/NappingNightingales/Assets/Prefabs/Enemy.prefab
+++ b/NappingNightingales/Assets/Prefabs/Enemy.prefab
@@ -141,7 +141,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3566968108666174483}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b7b8b17ce2b8040fa936580fd97bc5e5, type: 3}
   m_Name: 

--- a/NappingNightingales/Assets/Scenes/Scene0.unity
+++ b/NappingNightingales/Assets/Scenes/Scene0.unity
@@ -384,11 +384,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3566968108666174481, guid: 67f29eb23319f4f55b6215d2bb804434, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -2.64
+      value: -4.55
       objectReference: {fileID: 0}
     - target: {fileID: 3566968108666174481, guid: 67f29eb23319f4f55b6215d2bb804434, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -3.04
+      value: -7.43
       objectReference: {fileID: 0}
     - target: {fileID: 3566968108666174481, guid: 67f29eb23319f4f55b6215d2bb804434, type: 3}
       propertyPath: m_LocalPosition.z
@@ -574,11 +574,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3566968108666174481, guid: 67f29eb23319f4f55b6215d2bb804434, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 6.59
+      value: 7.26
       objectReference: {fileID: 0}
     - target: {fileID: 3566968108666174481, guid: 67f29eb23319f4f55b6215d2bb804434, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1.72
+      value: -5.44
       objectReference: {fileID: 0}
     - target: {fileID: 3566968108666174481, guid: 67f29eb23319f4f55b6215d2bb804434, type: 3}
       propertyPath: m_LocalPosition.z

--- a/NappingNightingales/Assets/Scripts/Gameplay/EnemyController.cs
+++ b/NappingNightingales/Assets/Scripts/Gameplay/EnemyController.cs
@@ -54,5 +54,9 @@ public class EnemyController : MonoBehaviour
             Destroy(this.gameObject);
         }
     }
+
+    private void OnBecameVisible() {
+        enabled = true;
+    }
     
 }


### PR DESCRIPTION
Enemies do not start shooting until they come into view of the camera.